### PR TITLE
Correctly handle parenthesized URLs

### DIFF
--- a/src/matrixmessageparser.ts
+++ b/src/matrixmessageparser.ts
@@ -105,8 +105,9 @@ export class MatrixMessageParser {
         }
         const escapeChars = ["\\", "*", "_", "~", "`", "|", ":"];
         const escapeDiscordInternal = (s: string): string => {
-            if (s.match(/^https?:\/\//)) {
-                return s;
+            const match = s.match(/\bhttps?:\/\//);
+            if (match) {
+                return escapeDiscordInternal(s.substring(0, match.index)) + s.substring(match.index as number);
             }
             escapeChars.forEach((char) => {
                 s = s.replace(new RegExp("\\" + char, "g"), "\\" + char);

--- a/test/test_matrixmessageparser.ts
+++ b/test/test_matrixmessageparser.ts
@@ -94,6 +94,12 @@ describe("MatrixMessageParser", () => {
             const result = await mp.FormatMessage(defaultOpts, msg);
             expect(result).is.equal("\\*hey\\*\nhttps://example.org/_blah_");
         });
+        it("leaves URLs between parentheses alone", async () => {
+            const mp = new MatrixMessageParser();
+            const msg = getPlainMessage("*hey* (https://example.org/_blah_)");
+            const result = await mp.FormatMessage(defaultOpts, msg);
+            expect(result).is.equal("\\*hey\\* (https://example.org/_blah_)");
+        });
     });
     describe("FormatMessage / formatted_body / simple", () => {
         it("leaves blank stuff untouched", async () => {


### PR DESCRIPTION
Sending URLs between parentheses, e.g. (https://example.com/test_link), would result in the underscore getting escaped and "auto-corrected" to a forward slash by Discord, resulting in Discord displaying (https://example.com/test/_link). This PR aims to fix that.