### PR TITLE
Don't show embed for matrix.to links

### DIFF
--- a/src/matrixmessageparser.ts
+++ b/src/matrixmessageparser.ts
@@ -190,7 +190,7 @@ export class MatrixMessageParser {
                 break;
         }
         if (!reply) {
-            return await this.parseLinkContent(opts, node);
+            return "<" + await this.parseLinkContent(opts, node) + ">";
         }
         return reply;
     }


### PR DESCRIPTION
This hides the matrix.to title and description from appearing whenever someone on matrix mentions another matrix user.