### PR TITLE
Apply rot13 to discord spoilers in unformatted matrix message body

### DIFF
--- a/src/discordmessageparser.ts
+++ b/src/discordmessageparser.ts
@@ -274,7 +274,7 @@ export class DiscordMessageParser {
         // matrix spoilers are still in MSC stage
         // see https://github.com/matrix-org/matrix-doc/pull/2010
         if (!html) {
-            return `(Spoiler: ${node.content})`;
+            return `(Spoiler (rot13): ${Util.Rot13(node.content)})`;
         }
         return `<span data-mx-spoiler>${node.content}</span>`;
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,6 +30,22 @@ export class Util {
         return htmlColor;
     }
 
+    public static Rot13(plaintext: string): string {
+        const UPPER_Z = 90;
+        const LOWER_Z = 122;
+        const CAESAR_SHIFT = 13;
+        const ALPHABET_LENGTH = 26;
+        return plaintext.replace(/[a-zA-Z]/g, (c) => {
+            const code = c.charCodeAt(0);
+            let shiftedCode = code + CAESAR_SHIFT;
+            if ((code <= UPPER_Z && shiftedCode > UPPER_Z)
+                || (code <= LOWER_Z && shiftedCode > LOWER_Z)) {
+                shiftedCode = shiftedCode - ALPHABET_LENGTH;
+            }
+            return String.fromCharCode(shiftedCode);
+        });
+    }
+
     public static async AsyncForEach(arr, callback) {
         for (let i = 0; i < arr.length; i++) {
             await callback(arr[i], i, arr);

--- a/test/test_discordmessageparser.ts
+++ b/test/test_discordmessageparser.ts
@@ -350,7 +350,7 @@ describe("DiscordMessageParser", () => {
             const mp = new DiscordMessageParser();
             const msg = getMessage("||foxies||");
             const result = await mp.FormatMessage(defaultOpts, msg);
-            expect(result.body).is.equal("(Spoiler: foxies)");
+            expect(result.body).is.equal("(Spoiler (rot13): sbkvrf)");
             expect(result.formattedBody).is.equal("<span data-mx-spoiler>foxies</span>");
         });
         it("processes unknown emoji correctly", async () => {


### PR DESCRIPTION
Currently, spoilered text from a discord message appears verbatim in the unformatted body of the corresponding matrix message. This isn't ideal, since it shows up in contexts such as desktop notifications. My proposal is to display the spoiler contents in rot13, a commonly-used format for spoilers on various platforms that don't offer native spoiler functionality. This preserves the semantics of the spoiler even when HTML display isn't available, and ensures that matrix users won't be shown content they may not have wanted to see.