### PR TITLE
Initial barebones parsing of Discord inline replies

### DIFF
--- a/src/discordtypes.ts
+++ b/src/discordtypes.ts
@@ -75,8 +75,14 @@ export interface IDiscordMessage {
     };
     author: {
         bot: boolean;
+        id: string;
+        username: string;
     };
+    reference: {
+        messageID: string;
+    } | null;
     guild?: IDiscordGuild | null;
     content: string;
     embeds: IDiscordMessageEmbed[];
+    webhookID: string;
 }


### PR DESCRIPTION
This PR should be merged the same time as the one in [matrix-appservice-discord](https://github.com/Half-Shot/matrix-appservice-discord/pull/704) and then synced versions as they do not work independent of eachother.

Adds very basic replies support, which should be good enough for most end-users. Currently missing parsing of Matrix user-pills (as demod on end result). Handles edits fine as well.

End result:
![image](https://user-images.githubusercontent.com/17257449/119488431-3693cd00-bd63-11eb-9ef2-d430e427bdc5.png)
