### PR TITLE
Replaced escaping and unescaping html entity libraries.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,15 +5,15 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "matrix-discord-parser",
       "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "discord-markdown": "git://github.com/Sorunome/discord-markdown.git#d710d3b1ee189193636e1d37cda281a60f5fc849",
-        "escape-html": "^1.0.3",
         "got": "^11.6.0",
         "highlight.js": "^10.4.1",
-        "node-html-parser": "^1.4.5",
-        "unescape-html": "^1.1.0"
+        "html-entities": "^2.3.2",
+        "node-html-parser": "^1.4.5"
       },
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.1",
@@ -1295,11 +1295,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -1692,6 +1687,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ=="
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -3541,11 +3541,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/unescape-html": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unescape-html/-/unescape-html-1.1.0.tgz",
-      "integrity": "sha512-O9/yBNqIkArjS597iHez5hAaAdn7b8/230SX8IncgXAX5tWI9XlEQYaz6Qbou0Sloa9n6lx9G5s6hg5qhJyzGg=="
-    },
     "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -4832,11 +4827,6 @@
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-    },
     "escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -5096,6 +5086,11 @@
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+    },
+    "html-entities": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ=="
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -6498,11 +6493,6 @@
       "integrity": "sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==",
       "dev": true,
       "optional": true
-    },
-    "unescape-html": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unescape-html/-/unescape-html-1.1.0.tgz",
-      "integrity": "sha512-O9/yBNqIkArjS597iHez5hAaAdn7b8/230SX8IncgXAX5tWI9XlEQYaz6Qbou0Sloa9n6lx9G5s6hg5qhJyzGg=="
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,10 @@
   "homepage": "https://github.com/matrix-discord/matrix-discord-parser#readme",
   "dependencies": {
     "discord-markdown": "git://github.com/Sorunome/discord-markdown.git#d710d3b1ee189193636e1d37cda281a60f5fc849",
-    "escape-html": "^1.0.3",
     "got": "^11.6.0",
     "highlight.js": "^10.4.1",
-    "node-html-parser": "^1.4.5",
-    "unescape-html": "^1.1.0"
+    "html-entities": "^2.3.2",
+    "node-html-parser": "^1.4.5"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",

--- a/src/discordmessageparser.ts
+++ b/src/discordmessageparser.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { IDiscordMessage, IDiscordMessageEmbed } from "./discordtypes";
 import * as markdown from "discord-markdown";
-import * as escapeHtml from "escape-html";
+import * as htmlEntities from "html-entities";
 import { Util } from "./util";
 
 const MATRIX_TO_LINK = "https://matrix.to/#/";
@@ -134,7 +134,7 @@ export class DiscordMessageParser {
             formattedBody: "",
         };
         oldMsg.content = `*edit:* ~~${oldMsg.content}~~ -> ${newMsg.content}`;
-        const linkStart = link ? `<a href="${escapeHtml(link)}">` : "";
+        const linkStart = link ? `<a href="${htmlEntities.encode(link)}">` : "";
         const linkEnd = link ? "</a>" : "";
         if (oldMsg.content.includes("\n") || newMsg.content.includes("\n")
             || newMsg.content.length > MAX_EDIT_MSG_LENGTH) {
@@ -161,7 +161,7 @@ export class DiscordMessageParser {
                 embedContent += "\n##### " + embedTitle; // h5 is probably best.
             }
             if (embed.author && embed.author.name) {
-                embedContent += `\n**${escapeHtml(embed.author.name)}**`;
+                embedContent += `\n**${htmlEntities.encode(embed.author.name)}**`;
             }
             if (embed.description) {
                 embedContent += "\n" + markdown.toHTML(embed.description, {
@@ -214,13 +214,13 @@ export class DiscordMessageParser {
             }
             let embedContent = content ? "<hr>" : "";
             const embedTitle = embed.url ?
-                `<a href="${escapeHtml(embed.url)}">${escapeHtml(embed.title)}</a>`
-                : (embed.title ? escapeHtml(embed.title) : undefined);
+                `<a href="${htmlEntities.encode(embed.url)}">${htmlEntities.encode(embed.title)}</a>`
+                : (embed.title ? htmlEntities.encode(embed.title) : undefined);
             if (embedTitle) {
                 embedContent += `<h5>${embedTitle}</h5>`; // h5 is probably best.
             }
             if (embed.author && embed.author.name) {
-                embedContent += `<strong>${escapeHtml(embed.author.name)}</strong><br>`;
+                embedContent += `<strong>${htmlEntities.encode(embed.author.name)}</strong><br>`;
             }
             if (embed.description) {
                 embedContent += "<p>";
@@ -234,7 +234,7 @@ export class DiscordMessageParser {
             }
             if (embed.fields) {
                 for (const field of embed.fields) {
-                    embedContent += `<p><strong>${escapeHtml(field.name)}</strong><br>`;
+                    embedContent += `<p><strong>${htmlEntities.encode(field.name)}</strong><br>`;
                     embedContent += markdown.toHTML(field.value, {
                         discordCallback: this.getDiscordParseCallbacks(opts, msg),
                         embed: true,
@@ -245,7 +245,7 @@ export class DiscordMessageParser {
                 }
             }
             if (embed.image) {
-                const imgUrl = escapeHtml(embed.image.url);
+                const imgUrl = htmlEntities.encode(embed.image.url);
                 embedContent += `<p>Image: <a href="${imgUrl}">${imgUrl}</a></p>`;
             }
             if (embed.footer) {
@@ -301,7 +301,7 @@ export class DiscordMessageParser {
             return `@${role.name}`;
         }
         const color = Util.NumberToHTMLColor(role.color);
-        return `<span data-mx-color="${color}"><strong>@${escapeHtml(role.name)}</strong></span>`;
+        return `<span data-mx-color="${color}"><strong>@${htmlEntities.encode(role.name)}</strong></span>`;
     }
 
     public InsertEmoji(opts: IDiscordMessageParserOpts, node: IEmojiNode): string {
@@ -327,7 +327,7 @@ export class DiscordMessageParser {
             const animated = results[ANIMATED_MXC_INSERT_REGEX_GROUP] === "1";
             const id = results[ID_MXC_INSERT_REGEX_GROUP];
             let replace = "";
-            const nameHtml = escapeHtml(name);
+            const nameHtml = htmlEntities.encode(name);
             const mxcUrl = await opts.callbacks.getEmoji(name, animated, id);
             if (mxcUrl) {
                 if (html) {
@@ -361,10 +361,10 @@ export class DiscordMessageParser {
             const user = await opts.callbacks.getUser(id);
             let replace = "";
             if (user) {
-                replace = html ? `<a href="${MATRIX_TO_LINK}${escapeHtml(user.mxid)}">` +
-                    `${escapeHtml(user.name)}</a>` : `${user.name} (${user.mxid})`;
+                replace = html ? `<a href="${MATRIX_TO_LINK}${htmlEntities.encode(user.mxid)}">` +
+                    `${htmlEntities.encode(user.name)}</a>` : `${user.name} (${user.mxid})`;
             } else {
-                replace = html ? `&lt;@${escapeHtml(id)}&gt;` : `<@${id}>`;
+                replace = html ? `&lt;@${htmlEntities.encode(id)}&gt;` : `<@${id}>`;
             }
             content = content.replace(results[0], replace);
             results = USER_INSERT_REGEX.exec(content);
@@ -385,10 +385,10 @@ export class DiscordMessageParser {
             let replace = "";
             if (channel) {
                 const name = "#" + channel.name;
-                replace = html ? `<a href="${MATRIX_TO_LINK}${escapeHtml(channel.mxid)}">` +
-                    `${escapeHtml(name)}</a>` : name;
+                replace = html ? `<a href="${MATRIX_TO_LINK}${htmlEntities.encode(channel.mxid)}">` +
+                    `${htmlEntities.encode(name)}</a>` : name;
             } else {
-                replace = html ? `&lt;#${escapeHtml(id)}&gt;` : `<#${id}>`;
+                replace = html ? `&lt;#${htmlEntities.encode(id)}&gt;` : `<#${id}>`;
             }
             content = content.replace(results[0], replace);
             results = CHANNEL_INSERT_REGEX.exec(content);

--- a/src/matrixmessageparser.ts
+++ b/src/matrixmessageparser.ts
@@ -19,7 +19,7 @@ import { IMatrixMessage, IMatrixEvent } from "./matrixtypes";
 import * as Parser from "node-html-parser";
 import { Util } from "./util";
 import * as highlightjs from "highlight.js";
-import * as unescapeHtml from "unescape-html";
+import * as htmlEntities from "html-entities";
 import got from "got";
 
 const MIN_NAME_LENGTH = 2;
@@ -94,7 +94,7 @@ export class MatrixMessageParser {
     }
 
     private async escapeDiscord(opts: IMatrixMessageParserOpts, msg: string): Promise<string> {
-        msg = unescapeHtml(msg);
+        msg = htmlEntities.decode(msg);
         // \u200B is the zero-width space --> they still look the same but don't mention
         msg = msg.replace(/@everyone/g, "@\u200Beveryone");
         msg = msg.replace(/@here/g, "@\u200Bhere");
@@ -128,7 +128,7 @@ export class MatrixMessageParser {
         let text = node.text;
         const match = text.match(/^<code([^>]*)>/i);
         if (!match) {
-            text = unescapeHtml(text);
+            text = htmlEntities.decode(text);
             if (text[0] !== "\n") {
                 text = "\n" + text;
             }
@@ -138,7 +138,7 @@ export class MatrixMessageParser {
         text = text.substr(match[0].length);
         // remove </code> closing tag
         text = text.replace(/<\/code>$/i, "");
-        text = unescapeHtml(text);
+        text = htmlEntities.decode(text);
         if (text[0] !== "\n") {
             text = "\n" + text;
         }


### PR DESCRIPTION
`escape-html` and `unescape-html` does not support all HTML & XML entities, which can lead to things such as apostrophes not being decoded properly from Matrix.