### PR TITLE
changed 'git' to 'git+https' due to unavailability

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/matrix-discord/matrix-discord-parser#readme",
   "dependencies": {
-    "discord-markdown": "git://github.com/Sorunome/discord-markdown.git#d710d3b1ee189193636e1d37cda281a60f5fc849",
+    "discord-markdown": "git+https://github.com/Sorunome/discord-markdown.git#d710d3b1ee189193636e1d37cda281a60f5fc849",
     "escape-html": "^1.0.3",
     "got": "^11.6.0",
     "highlight.js": "^10.4.1",


### PR DESCRIPTION
GitHub removed the unencrypted Git protocol. `git://` works if a ssh-key is set up at GitHub, but don't work elsewhere (like production environments):
https://github.blog/2021-09-01-improving-git-protocol-security-github/

If you install it as dependency (here from `mx-puppet-discord`), you get following error from `yarn`:
```sh
$ yarn
yarn install v1.22.17
info No lockfile found.
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/4] Resolving packages...
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads git://github.com/Sorunome/discord-markdown.git
Directory: /home/discord-puppet/test
Output:
fatal: Fehler am anderen Ende: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

The funny thing is, that it works with `npm` without errors (got a heart-attack from it that I can't reproduce the error anymore^^):
```sh
$ npm i
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@sorunome/matrix-bot-sdk@0.5.13',
npm WARN EBADENGINE   required: { node: '>=10.0.0', npm: '^6.0.0', yarn: '^1.19.0' },
npm WARN EBADENGINE   current: { node: 'v16.14.0', npm: '8.3.1' }
npm WARN EBADENGINE }
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.

added 383 packages, and audited 384 packages in 5s

34 packages are looking for funding
  run `npm fund` for details

2 moderate severity vulnerabilities

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
```

Following patch corrects the URI specifier that dependency installation works over HTTPS, so the error can't happen anymore.