### PR TITLE
package.json: replace defunct `git:` URLs 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "matrix-discord-parser",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "matrix-discord-parser",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "discord-markdown": "git://github.com/Sorunome/discord-markdown.git#d710d3b1ee189193636e1d37cda281a60f5fc849",
+        "discord-markdown": "git+https://github.com/Sorunome/discord-markdown.git#d710d3b1ee189193636e1d37cda281a60f5fc849",
         "escape-html": "^1.0.3",
         "got": "^11.6.0",
         "highlight.js": "^10.4.1",
@@ -4794,7 +4794,7 @@
     "discord-markdown": {
       "version": "git+ssh://git@github.com/Sorunome/discord-markdown.git#d710d3b1ee189193636e1d37cda281a60f5fc849",
       "integrity": "sha512-/uVXEq6i6/xtL7THG1adPhkA+DPUUZcN2O1blTC3wOCwL2GDhkn3uTiD6Vbe2yqPizAZEWWbGYjECN728iDv/Q==",
-      "from": "discord-markdown@git://github.com/Sorunome/discord-markdown.git#d710d3b1ee189193636e1d37cda281a60f5fc849",
+      "from": "discord-markdown@git+https://github.com/Sorunome/discord-markdown.git#d710d3b1ee189193636e1d37cda281a60f5fc849",
       "requires": {
         "highlight.js": "^10.4.1",
         "node-emoji": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/matrix-discord/matrix-discord-parser#readme",
   "dependencies": {
-    "discord-markdown": "git://github.com/Sorunome/discord-markdown.git#d710d3b1ee189193636e1d37cda281a60f5fc849",
+    "discord-markdown": "git+https://github.com/Sorunome/discord-markdown.git#d710d3b1ee189193636e1d37cda281a60f5fc849",
     "escape-html": "^1.0.3",
     "got": "^11.6.0",
     "highlight.js": "^10.4.1",


### PR DESCRIPTION
This project specifies `git:` URLs as dependencies, but `git:` URLs are no longer supported by GitHub.  Consequently, `yarn` is unable to add this project as a dependency, as it times out when trying to download dependencies via `git:` URLs.

An example dependant project is [matrix-appservice-discord](https://github.com/matrix-org/matrix-appservice-discord), for which `yarn install` fails as follows:

```
$ yarn install
yarn install v1.22.18
[1/4] Resolving packages...
[2/4] Fetching packages...
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads git://github.com/Sorunome/better-discord.js.git
Directory: /tmp/test/matrix-appservice-discord
Output:
fatal: unable to connect to github.com:
github.com[0: 140.82.113.3]: errno=Connection timed out
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Updating these URLs allows `yarn` projects to use this project as a dependency without requiring manual edits of their `yarn.lock` files.

Follow-up of https://github.com/matrix-org/matrix-appservice-discord/pull/777.