### PR TITLE
package.json: replace defunct `git:` URLs (v0.1.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-discord-parser",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -588,8 +588,8 @@
       "dev": true
     },
     "discord-markdown": {
-      "version": "git://github.com/Sorunome/discord-markdown.git#7958a03a952ed02cbd588b09eb04bc070b3a11f2",
-      "from": "git://github.com/Sorunome/discord-markdown.git#7958a03a952ed02cbd588b09eb04bc070b3a11f2",
+      "version": "git+https://github.com/Sorunome/discord-markdown.git#7958a03a952ed02cbd588b09eb04bc070b3a11f2",
+      "from": "git+https://github.com/Sorunome/discord-markdown.git#7958a03a952ed02cbd588b09eb04bc070b3a11f2",
       "requires": {
         "highlight.js": "^9.18.1",
         "node-emoji": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/matrix-discord/matrix-discord-parser#readme",
   "dependencies": {
-    "discord-markdown": "git://github.com/Sorunome/discord-markdown.git#7958a03a952ed02cbd588b09eb04bc070b3a11f2",
+    "discord-markdown": "git+https://github.com/Sorunome/discord-markdown.git#7958a03a952ed02cbd588b09eb04bc070b3a11f2",
     "escape-html": "^1.0.3",
     "got": "^11.6.0",
     "highlight.js": "^9.18.1",


### PR DESCRIPTION
This is analogous to https://github.com/matrix-discord/matrix-discord-parser/pull/28 for v0.1.5, which is what [matrix-appservice-discord](https://github.com/matrix-org/matrix-appservice-discord) uses as a dependency.